### PR TITLE
RPC updates and additions. Sync fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ debug/
 *.o
 
 src/Lindad
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ src/qt/locale/*.qm
 
 release/
 debug/
+*.P
+
+*.o
+
+src/Lindad

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -212,7 +212,7 @@ cd ~/deps
 tar xvfz miniupnpc-1.9.tar.gz
 
 cd miniupnpc-1.9
-make init upnpc-static
+make upnpc-static
 ```
 ==> Important : don't forget to rename "miniupnpc-1.9" directory to "miniupnpc"
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -267,10 +267,10 @@ build libsecp256k1
 ```
 cd ~/Linda/src/secp256k1
 ./autogen.sh
-./configure
+./configure --enable-static --disable-shared
 make
 ```
-Just by precaution, go to secp256k1/.libs dir and delete all non static libs (all except *.a files) to make sure only that one will be used during linking
+Just by precaution, go to secp256k1/.libs dir and delete all non static libs (all except *.a files) if present, to make sure only static libs will be used during linking
 
 go back to Lindacoin dir to modify Linda-qt.pro if needed :
 ```

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -71,14 +71,14 @@ void CActiveMasternode::ManageStatus()
             }
         
 
-        if(pwalletMain->IsLocked())
+        if(pwalletMain->IsLocked(true))
         {
             notCapableReason = "Wallet is locked.";
             status = MASTERNODE_NOT_CAPABLE;
             LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason.c_str());
             return;
         }
-
+        
         // Set defaults
         status = MASTERNODE_NOT_CAPABLE;
         notCapableReason = "Unknown. Check debug.log for more information.\n";

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -21,7 +21,8 @@ void CActiveMasternode::ManageStatus()
 
     //need correct adjusted time to send ping
     bool fIsInitialDownload = IsInitialBlockDownload();
-    if(fIsInitialDownload) {
+    if(fIsInitialDownload) 
+    {
         status = MASTERNODE_SYNC_IN_PROCESS;
         LogPrintf("CActiveMasternode::ManageStatus() - Sync in progress. Must wait until sync is complete to start masternode.\n");
         return;
@@ -31,15 +32,21 @@ void CActiveMasternode::ManageStatus()
         status = MASTERNODE_NOT_PROCESSED;
     }
 
-    if(status == MASTERNODE_NOT_PROCESSED) {
-        if(strMasterNodeAddr.empty()) {
-            if(!GetLocal(service)) {
+    if(status == MASTERNODE_NOT_PROCESSED) 
+    {
+        if(strMasterNodeAddr.empty()) 
+        {
+            if(!GetLocal(service)) 
+            {
                 notCapableReason = "Can't detect external address. Please use the masternodeaddr configuration option.";
                 status = MASTERNODE_NOT_CAPABLE;
                 LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason.c_str());
                 return;
             }
-        } else {
+
+        } 
+        else 
+        {
         	service = CService(strMasterNodeAddr);
         }
 
@@ -55,7 +62,8 @@ void CActiveMasternode::ManageStatus()
         */
 
         
-            if(!ConnectNode((CAddress)service, service.ToString().c_str())){
+            if(!ConnectNode((CAddress)service, service.ToString().c_str()))
+            {
                 notCapableReason = "Could not connect to " + service.ToString();
                 status = MASTERNODE_NOT_CAPABLE;
                 LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason.c_str());
@@ -63,7 +71,8 @@ void CActiveMasternode::ManageStatus()
             }
         
 
-        if(pwalletMain->IsLocked()){
+        if(pwalletMain->IsLocked())
+        {
             notCapableReason = "Wallet is locked.";
             status = MASTERNODE_NOT_CAPABLE;
             LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason.c_str());
@@ -78,9 +87,11 @@ void CActiveMasternode::ManageStatus()
         CPubKey pubKeyCollateralAddress;
         CKey keyCollateralAddress;
 
-        if(GetMasterNodeVin(vin, pubKeyCollateralAddress, keyCollateralAddress)) {
+        if(GetMasterNodeVin(vin, pubKeyCollateralAddress, keyCollateralAddress)) 
+        {
 
-            if(GetInputAge(vin) < MASTERNODE_MIN_CONFIRMATIONS){
+            if(GetInputAge(vin) < MASTERNODE_MIN_CONFIRMATIONS)
+            {
                 LogPrintf("CActiveMasternode::ManageStatus() - Input must have least %d confirmations - %d confirmations\n", MASTERNODE_MIN_CONFIRMATIONS, GetInputAge(vin));
                 status = MASTERNODE_INPUT_TOO_NEW;
                 return;
@@ -103,20 +114,26 @@ void CActiveMasternode::ManageStatus()
             	return;
             }
 
-            if(!Register(vin, service, keyCollateralAddress, pubKeyCollateralAddress, keyMasternode, pubKeyMasternode, errorMessage)) {
+            if(!Register(vin, service, keyCollateralAddress, pubKeyCollateralAddress, keyMasternode, pubKeyMasternode, errorMessage)) 
+            {
             	LogPrintf("CActiveMasternode::ManageStatus() - Error on Register: %s\n", errorMessage.c_str());
             }
 
             return;
-        } else {
+        } 
+        else 
+        {
         	LogPrintf("CActiveMasternode::ManageStatus() - Could not find suitable coins!\n");
         }
+
     }
 
     //send to all peers
-    if(!Dseep(errorMessage)) {
+    if(!Dseep(errorMessage)) 
+    {
     	LogPrintf("CActiveMasternode::ManageStatus() - Error on Ping: %s", errorMessage.c_str());
     }
+    
 }
 
 // Send stop dseep to network for remote masternode

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       2
 #define CLIENT_VERSION_MINOR       0
 #define CLIENT_VERSION_REVISION    0
-#define CLIENT_VERSION_BUILD       0
+#define CLIENT_VERSION_BUILD       1
 
 // Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE  true

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2025,7 +2025,14 @@ bool CDarkSendSigner::IsVinAssociatedWithPubkey(CTxIn& vin, CPubKey& pubkey){
     {
         BOOST_FOREACH(CTxOut out, txVin.vout)
         {
-            if(out.nValue == nDarkSendCollateral*COIN)
+            // MBK: Added some additional degugging information
+            if(MBK_EXTRA_DEBUG)
+            {
+                LogPrintf("CDarkSendSigner::IsVinAssociatedWithPubkey() -> nValue=%d(%s) nDarkSendCollateral=%d(%s) extra=%d\n", out.nValue, FormatMoney(out.nValue), nDarkSendCollateral, FormatMoney(nDarkSendCollateral), nDarkSendCollateral*COIN);            
+            }
+
+            // MBK: Corrected calculation. *COIN is done in main.h and should have been removed
+            if(out.nValue == nDarkSendCollateral/**COIN*/)
             {
                 if(out.scriptPubKey == payee2) return true;
             }

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -225,7 +225,7 @@ class CDarksendSession
 class CDarkSendPool
 {
 public:
-    static const int MIN_PEER_PROTO_VERSION = 60032;
+    static const int MIN_PEER_PROTO_VERSION = 60020;
 
     // clients entries
     std::vector<CDarkSendEntry> myEntries;

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -225,7 +225,7 @@ class CDarksendSession
 class CDarkSendPool
 {
 public:
-    static const int MIN_PEER_PROTO_VERSION = 60020;
+    static const int MIN_PEER_PROTO_VERSION = 60032;
 
     // clients entries
     std::vector<CDarkSendEntry> myEntries;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -182,6 +182,7 @@ std::string HelpMessage()
     strUsage += "  -dns                   " + _("Allow DNS lookups for -addnode, -seednode and -connect") + "\n";
     strUsage += "  -port=<port>           " + _("Listen for connections on <port> (default: 15714 or testnet: 25714)") + "\n";
     strUsage += "  -maxconnections=<n>    " + _("Maintain at most <n> connections to peers (default: 125)") + "\n";
+    strUsage += "  -maxorphantx=<n>       " + _("Keep at most <n> unconnectable transactions in memory (default: 400000)") + "\n";
     strUsage += "  -addnode=<ip>          " + _("Add a node to connect to and attempt to keep the connection open") + "\n";
     strUsage += "  -connect=<ip>          " + _("Connect only to the specified node(s)") + "\n";
     strUsage += "  -seednode=<ip>         " + _("Connect to a node to retrieve peer addresses, and disconnect") + "\n";

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -182,7 +182,7 @@ std::string HelpMessage()
     strUsage += "  -dns                   " + _("Allow DNS lookups for -addnode, -seednode and -connect") + "\n";
     strUsage += "  -port=<port>           " + _("Listen for connections on <port> (default: 15714 or testnet: 25714)") + "\n";
     strUsage += "  -maxconnections=<n>    " + _("Maintain at most <n> connections to peers (default: 125)") + "\n";
-    strUsage += "  -maxorphantx=<n>       " + _("Keep at most <n> unconnectable transactions in memory (default: 400000)") + "\n";
+    strUsage += "  -maxorphantx=<n>       " + strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS) + "\n";
     strUsage += "  -addnode=<ip>          " + _("Add a node to connect to and attempt to keep the connection open") + "\n";
     strUsage += "  -connect=<ip>          " + _("Connect only to the specified node(s)") + "\n";
     strUsage += "  -seednode=<ip>         " + _("Connect to a node to retrieve peer addresses, and disconnect") + "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,6 +165,7 @@ void FinalizeNode(NodeId pnode) {
     {
         if(pn->GetId() == pnode)
         {
+            LogPrintf("FinalizeNode:: %i\n", pn->addr.ToString().c_str());
             BOOST_FOREACH(const QueuedBlock& entry, pn->vBlocksInFlight)
                 mapBlocksInFlight.erase(entry.hash);
             BOOST_FOREACH(const uint256& hash, pn->vBlocksToDownload)
@@ -2942,8 +2943,6 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock)
 
         // Accept orphans as long as there is a node to request its parents from
         if (pfrom) {
-            // ban nodes who send too many orphans
-            pfrom->Misbehaving(1);
             // ppcoin: check proof-of-stake
             if (pblock->IsProofOfStake())
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4430,6 +4430,6 @@ int64_t GetMasternodePayment(int nHeight, int64_t blockValue)
 {
     // MBK: Set masternode reward phase
     //      NOTE: Fixed the reward, now it actually is applied to blockValue
-    int64_t ret = static_cast<int64_t>(blockHeight * 0.677777777777777777); // ~2/3 masternode stake reward
+    int64_t ret = static_cast<int64_t>(blockValue * 0.677777777777777777); // ~2/3 masternode stake reward
     return ret;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3943,7 +3943,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             AddOrphanTx(tx);
 
             // DoS prevention: do not allow mapOrphanTransactions to grow unbounded
-            unsigned int nEvicted = LimitOrphanTxSize(MAX_ORPHAN_TRANSACTIONS);
+            unsigned int nMaxOrphanTx = (unsigned int)std::max((int64_t)0, GetArg("-maxorphantx", DEFAULT_MAX_ORPHAN_TRANSACTIONS));
+            unsigned int nEvicted = LimitOrphanTxSize(nMaxOrphanTx);
             if (nEvicted > 0)
                 LogPrint("mempool", "mapOrphan overflow, removed %u tx\n", nEvicted);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4430,6 +4430,6 @@ int64_t GetMasternodePayment(int nHeight, int64_t blockValue)
 {
     // MBK: Set masternode reward phase
     //      NOTE: Fixed the reward, now it actually is applied to blockValue
-    int64_t ret = static_cast<int64_t>(blockValue * 0.677777777777777777); // ~2/3 masternode stake reward
+    int64_t ret = static_cast<int64_t>(blockHeight * 0.677777777777777777); // ~2/3 masternode stake reward
     return ret;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4429,6 +4429,7 @@ bool SendMessages(CNode* pto, bool fSendTrickle)
 int64_t GetMasternodePayment(int nHeight, int64_t blockValue)
 {
     // MBK: Set masternode reward phase
-    int64_t ret = static_cast<int64_t>(67.33333333333333333); // ~2/3 masternode stake reward
+    //      NOTE: Fixed the reward, now it actually is applied to blockValue
+    int64_t ret = static_cast<int64_t>(blockValue * 0.677777777777777777); // ~2/3 masternode stake reward
     return ret;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2918,6 +2918,8 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock)
 
         // Accept orphans as long as there is a node to request its parents from
         if (pfrom) {
+            // ban nodes who send too many orphans
+            pfrom->Misbehaving(1);
             // ppcoin: check proof-of-stake
             if (pblock->IsProofOfStake())
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2513,13 +2513,13 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, bool fCheckSig) c
 
         CBlockIndex *pindex = pindexBest;
         if(pindex != NULL){
-            if(pindex->GetBlockHash() == hashPrevBlock){
-                CAmount masternodePaymentAmount = GetMasternodePayment(pindex->nHeight+1, vtx[0].GetValueOut());
+            if(pindex->GetBlockHash() == hashPrevBlock){                
                 bool fIsInitialDownload = IsInitialBlockDownload();
 
                 // If we don't already have its previous block, skip masternode payment step
-                if (!fIsInitialDownload && pindex != NULL)
+                if (!fIsInitialDownload)
                 {
+                    CAmount masternodePaymentAmount = GetMasternodePayment(pindex->nHeight+1, vtx[0].GetValueOut());
                     bool foundPaymentAmount = false;
                     bool foundPayee = false;
                     bool foundPaymentAndPayee = false;

--- a/src/main.h
+++ b/src/main.h
@@ -105,7 +105,7 @@ static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
 static const unsigned int MAX_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
 /** The maximum number of orphan transactions kept in memory */
-static const unsigned int MAX_ORPHAN_TRANSACTIONS = MAX_BLOCK_SIZE/100;
+static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = MAX_BLOCK_SIZE/100;
 /** Default for -maxorphanblocks, maximum number of orphan blocks kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_BLOCKS = 750;
 /** The maximum number of entries in an 'inv' protocol message */

--- a/src/main.h
+++ b/src/main.h
@@ -234,6 +234,9 @@ void ThreadStakeMiner(CWallet *pwallet);
 bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool fLimitFree,
                         bool* pfMissingInputs);
 
+bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction &tx, bool fLimitFree,
+                        bool* pfMissingInputs, std::string& errorMessage);
+
 bool AcceptableInputs(CTxMemPool& pool, const CTransaction &txo, bool fLimitFree,
                         bool* pfMissingInputs);
 

--- a/src/main.h
+++ b/src/main.h
@@ -120,6 +120,11 @@ inline bool MoneyRange(int64_t nValue) { return (nValue >= 0 && nValue <= MAX_MO
 /** Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp. */
 static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
 
+/** Number of blocks that can be requested at any given time from a single peer. */
+static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 32;
+/** Timeout in seconds before considering a block download peer unresponsive. */
+static const unsigned int BLOCK_DOWNLOAD_TIMEOUT = 60;
+
 static const int64_t COIN_YEAR_REWARD = 99 * CENT; // 99% per year
 static const unsigned int POS_START_BLOCK = 25;
 static const unsigned int DIFF_FORK_BLOCK = 100;

--- a/src/main.h
+++ b/src/main.h
@@ -121,13 +121,16 @@ inline bool MoneyRange(int64_t nValue) { return (nValue >= 0 && nValue <= MAX_MO
 static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
 
 /** Number of blocks that can be requested at any given time from a single peer. */
-static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 32;
+static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 128;
 /** Timeout in seconds before considering a block download peer unresponsive. */
 static const unsigned int BLOCK_DOWNLOAD_TIMEOUT = 60;
 
+/** default for -maxconnections, maximum number of connected peers */
+static const unsigned int DEFAULT_MAX_CONNECTIONS = 256;
+
 static const int64_t COIN_YEAR_REWARD = 99 * CENT; // 99% per year
-static const unsigned int POS_START_BLOCK = 25;
-static const unsigned int DIFF_FORK_BLOCK = 100;
+static const int POS_START_BLOCK = 25;
+static const int DIFF_FORK_BLOCK = 100;
 
 
 inline bool IsProtocolV1RetargetingFixed(int nHeight) { return TestNet() || nHeight >= 0; }

--- a/src/main.h
+++ b/src/main.h
@@ -105,7 +105,7 @@ static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
 static const unsigned int MAX_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
 /** The maximum number of orphan transactions kept in memory */
-static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = MAX_BLOCK_SIZE/100;
+static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default for -maxorphanblocks, maximum number of orphan blocks kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_BLOCKS = 750;
 /** The maximum number of entries in an 'inv' protocol message */

--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -11,6 +11,7 @@ void CMasternodeConfig::add(std::string alias, std::string ip, std::string privK
 }
 
 bool CMasternodeConfig::read(std::string& strErr) {
+    entries = std::vector<CMasternodeEntry>(); // Clear entries so we don't double up
     boost::filesystem::ifstream streamConfig(GetMasternodeConfigFile());
     if (!streamConfig.good()) {
         return true; // No masternode.conf file is OK
@@ -40,4 +41,61 @@ bool CMasternodeConfig::read(std::string& strErr) {
 
     streamConfig.close();
     return true;
+}
+
+bool CMasternodeConfig::create(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex) {
+    // check if already have masternode account
+    bool exists = false;
+    for (std::vector<CMasternodeEntry>::const_iterator it = entries.begin(); it != entries.end(); it++) {
+        if ((*it).getAlias() == alias) {
+            exists = true;
+            break; 
+        }
+    }
+
+    if (!exists) {
+        // update the masternode config file
+        boost::filesystem::ofstream streamConfig(GetMasternodeConfigFile());
+
+        for (std::vector<CMasternodeEntry>::const_iterator it = entries.begin(); it != entries.end(); it++) {
+            streamConfig << (*it).getAlias() << " " << (*it).getIp() << " " << (*it).getPrivKey() << " " << (*it).getTxHash() << " " << (*it).getOutputIndex() << std::endl;
+        }
+
+        // add the new masternode to config file
+        streamConfig << alias << " " << ip << " " << privKey << " " << txHash << " " << outputIndex << std::endl;
+
+        // add new masternode to entries
+        add(alias, ip, privKey, txHash, outputIndex);
+
+        streamConfig.close();
+        return true;
+    }
+
+    return false;
+}
+
+bool CMasternodeConfig::remove(std::string alias) {
+    // update masternode config file to remove the account
+    boost::filesystem::ofstream streamConfig(GetMasternodeConfigFile());
+    int rIndex = -1;
+    int i = 0;
+
+    for (std::vector<CMasternodeEntry>::const_iterator it = entries.begin(); it != entries.end(); it++) {
+        i++;
+        if ((*it).getAlias() != alias) {
+            streamConfig << (*it).getAlias() << " " << (*it).getIp() << " " << (*it).getPrivKey() << " " << (*it).getTxHash() << " " << (*it).getOutputIndex() << std::endl;
+        } else {
+            rIndex = i;
+        }
+    }
+    
+    streamConfig.close();
+
+    // remove from our entries
+    if (rIndex != -1) {
+        entries.erase(entries.begin()+rIndex);
+        return true;
+    }
+    
+    return false;    
 }

--- a/src/masternodeconfig.h
+++ b/src/masternodeconfig.h
@@ -86,6 +86,8 @@ public:
 	void clear();
     bool read(std::string& strErr);
 	void add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex);
+	bool create(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex);
+	bool remove(std::string alias);
 
 	std::vector<CMasternodeEntry>& getEntries() {
 		return entries;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -356,27 +356,41 @@ CNode* FindNode(const CService& addr)
 
 CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool darkSendMaster)
 {
-    if (pszDest == NULL) {
+    // MBK: Added additional debug information
+    if(MBK_EXTRA_DEBUG)
+    {
+        LogPrintf("ConnectNode() [PreNullCheck] -> pszDest=%s darkSendMaster=%s\n", (pszDest == NULL ? "NULL" : pszDest), (darkSendMaster == true ? "True" : "False"));
+    }
+
+    if (pszDest == NULL) 
+    {
         if (IsLocal(addrConnect))
+        {
+            // MBK: Added additional debug information
+            if(MBK_EXTRA_DEBUG)
+            {
+                LogPrintf("ConnectNode() [PostNullCheck] -> IsLocal() = True\n");
+            }
+
             return NULL;
+        }
 
         // Look for an existing connection
         CNode* pnode = FindNode((CService)addrConnect);
         if (pnode)
         {
-	    if(darkSendMaster)
+	        if(darkSendMaster)
                 pnode->fDarkSendMaster = true;
 
             pnode->AddRef();
             return pnode;
         }
+
     }
 
 
     /// debug print
-    LogPrint("net", "trying connection %s lastseen=%.1fhrs\n",
-        pszDest ? pszDest : addrConnect.ToString(),
-        pszDest ? 0 : (double)(GetAdjustedTime() - addrConnect.nTime)/3600.0);
+    LogPrint("net", "trying connection %s lastseen=%.1fhrs\n", pszDest ? pszDest : addrConnect.ToString(), pszDest ? 0 : (double)(GetAdjustedTime() - addrConnect.nTime)/3600.0);
 
     // Connect
     SOCKET hSocket;
@@ -409,7 +423,9 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool darkSendMaste
 
         pnode->nTimeConnected = GetTime();
         return pnode;
-    } else if (!proxyConnectionFailed) {
+    } 
+    else if (!proxyConnectionFailed) 
+    {
         // If connecting to the node failed, and failure is not caused by a problem connecting to
         // the proxy, mark this as an attempt.
         addrman.Attempt(addrConnect);
@@ -1582,6 +1598,7 @@ bool BindListenPort(const CService &addrBind, string& strError)
         LogPrintf("%s\n", strError);
         return false;
     }
+
     LogPrintf("Bound to %s\n", addrBind.ToString());
 
     // Listen for incoming connections

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -854,7 +854,7 @@ void ThreadSocketHandler()
                 if (nErr != WSAEWOULDBLOCK)
                     LogPrintf("socket error accept failed: %d\n", nErr);
             }
-            else if (nInbound >= GetArg("-maxconnections", 256) - MAX_OUTBOUND_CONNECTIONS)
+            else if (nInbound >= GetArg("-maxconnections", DEFAULT_MAX_CONNECTIONS) - MAX_OUTBOUND_CONNECTIONS)
             {
                 closesocket(hSocket);
             }
@@ -1423,7 +1423,7 @@ void static StartSync(const vector<CNode*> &vNodes) {
             int64_t nScore = NodeSyncScore(pnode);
             if (pnodeNewSync == NULL || nScore > nBestScore) {
                 pnodeNewSync = pnode;
-                nBestScore = nScore;
+                nBestScore = nScore;                
             }
         }
     }
@@ -1672,7 +1672,7 @@ void StartNode(boost::thread_group& threadGroup)
 {
     if (semOutbound == NULL) {
         // initialize semaphore
-        int nMaxOutbound = min(MAX_OUTBOUND_CONNECTIONS, (int)GetArg("-maxconnections", 125));
+        int nMaxOutbound = min(MAX_OUTBOUND_CONNECTIONS, (int)GetArg("-maxconnections", DEFAULT_MAX_CONNECTIONS));
         semOutbound = new CSemaphore(nMaxOutbound);
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1748,17 +1748,17 @@ public:
 }
 instance_of_cnetcleanup;
 
-void RelayTransaction(const CTransaction& tx, const uint256& hash)
+void RelayTransaction(const CTransaction& tx)
 {
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss.reserve(10000);
     ss << tx;
-    RelayTransaction(tx, hash, ss);
+    RelayTransaction(tx, ss);
 }
 
-void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataStream& ss)
+void RelayTransaction(const CTransaction& tx, const CDataStream& ss)
 {
-    CInv inv(MSG_TX, hash);
+    CInv inv(MSG_TX, tx.GetHash());
     {
         LOCK(cs_mapRelay);
         // Expire old relay messages
@@ -1776,7 +1776,7 @@ void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataSt
     RelayInventory(inv);
 }
 
-void RelayTransactionLockReq(const CTransaction& tx, const uint256& hash, bool relayToAll)
+void RelayTransactionLockReq(const CTransaction& tx, bool relayToAll)
 {
     CInv inv(MSG_TXLOCK_REQUEST, tx.GetHash());
 

--- a/src/net.h
+++ b/src/net.h
@@ -750,9 +750,9 @@ inline void RelayInventory(const CInv& inv)
 }
 
 class CTransaction;
-void RelayTransaction(const CTransaction& tx, const uint256& hash);
-void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataStream& ss);
-void RelayTransactionLockReq(const CTransaction& tx, const uint256& hash, bool relayToAll=false);
+void RelayTransaction(const CTransaction& tx);
+void RelayTransaction(const CTransaction& tx, const CDataStream& ss);
+void RelayTransactionLockReq(const CTransaction& tx, bool relayToAll=false);
 void RelayDarkSendFinalTransaction(const int sessionID, const CTransaction& txNew);
 void RelayDarkSendIn(const std::vector<CTxIn>& in, const int64_t& nAmount, const CTransaction& txCollateral, const std::vector<CTxOut>& out);
 void RelayDarkSendStatus(const int sessionID, const int newState, const int newEntriesCount, const int newAccepted, const std::string error="");

--- a/src/net.h
+++ b/src/net.h
@@ -231,6 +231,7 @@ public:
     bool fNetworkNode;
     bool fSuccessfullyConnected;
     bool fDisconnect;
+    bool fShouldBan;
     // We use fRelayTxes for two purposes -
     // a) it allows us to not relay tx invs before receiving the peer's version message
     // b) the peer may tell us in their version message that we should not relay tx invs
@@ -309,6 +310,7 @@ public:
         fNetworkNode = false;
         fSuccessfullyConnected = false;
         fDisconnect = false;
+        fShouldBan = false;
         nRefCount = 0;
         nSendSize = 0;
         nSendOffset = 0;

--- a/src/obj/build.h
+++ b/src/obj/build.h
@@ -1,0 +1,2 @@
+// No build information available
+#define BUILD_DATE ""

--- a/src/obj/build.h
+++ b/src/obj/build.h
@@ -1,2 +1,2 @@
 // No build information available
-#define BUILD_DATE ""
+#define BUILD_DATE "2018-04-28 22:19:02 +1000"

--- a/src/obj/scrypt-arm.d
+++ b/src/obj/scrypt-arm.d
@@ -1,0 +1,1 @@
+obj/scrypt-arm.o: scrypt-arm.S

--- a/src/obj/scrypt-x86.d
+++ b/src/obj/scrypt-x86.d
@@ -1,0 +1,1 @@
+obj/scrypt-x86.o: scrypt-x86.S

--- a/src/obj/scrypt-x86_64.d
+++ b/src/obj/scrypt-x86_64.d
@@ -1,0 +1,1 @@
+obj/scrypt-x86_64.o: scrypt-x86_64.S

--- a/src/rpcdarksend.cpp
+++ b/src/rpcdarksend.cpp
@@ -126,11 +126,11 @@ Value masternode(const Array& params, bool fHelp)
         strCommand = params[0].get_str();
 
     if (fHelp  ||
-        (strCommand != "init" && strCommand != "start" && strCommand != "start-alias" && strCommand != "start-many" && strCommand != "stop" && strCommand != "stop-alias" && strCommand != "stop-many" && strCommand != "list" && strCommand != "list-conf" && strCommand != "count"  && strCommand != "enforce"
+        (strCommand != "init" && strCommand != "isInit" && strCommand != "start" && strCommand != "start-alias" && strCommand != "start-many" && strCommand != "stop" && strCommand != "stop-alias" && strCommand != "stop-many" && strCommand != "kill" && strCommand != "list" && strCommand != "list-conf" && strCommand != "count"  && strCommand != "enforce"
             && strCommand != "debug" && strCommand != "current" && strCommand != "winners" && strCommand != "genkey" && strCommand != "connect" && strCommand != "outputs"
              && strCommand != "addremote" && strCommand != "removeremote" && strCommand != "status" && strCommand != "status-all"))
         throw runtime_error(
-            "masternode <init|start|start-alias|start-many|stop|stop-alias|stop-many|list|list-conf|count|debug|current|winners|genkey|enforce|outputs|addremote|removeremote|status|status-all> [passphrase]\n");
+            "masternode <init|isInit|start|start-alias|start-many|stop|stop-alias|stop-many|kill|list|list-conf|count|debug|current|winners|genkey|enforce|outputs|addremote|removeremote|status|status-all> [passphrase]\n");
 
     if (strCommand == "stop")
     {
@@ -688,6 +688,29 @@ Value masternode(const Array& params, bool fHelp)
 
         fMasterNode = true;
         LogPrintf("IS DARKSEND MASTER NODE\n");
+
+        return true;
+    }
+
+    if (strCommand == "kill") return fMasterNode = false;
+
+    if (strCommand == "isInit") {
+        // check flag and variables are set
+        if (!fMasterNode || strMasterNodeAddr == "" || strMasterNodePrivKey == "")
+            return false;
+        
+        // check valid address
+        CService addrTest = CService(strMasterNodeAddr);
+        if (!addrTest.IsValid())
+            return false;
+
+        std::string errorMessage;
+
+        CKey key;
+        CPubKey pubkey;
+
+        if(!darkSendSigner.SetKey(strMasterNodePrivKey, errorMessage, key, pubkey))
+            return false;
 
         return true;
     }

--- a/src/rpcdarksend.cpp
+++ b/src/rpcdarksend.cpp
@@ -319,7 +319,7 @@ Value masternode(const Array& params, bool fHelp)
     {
         if(!fMasterNode) return "you must set masternode=1 in the configuration";
 
-        if(pwalletMain->IsLocked()) {
+        if(pwalletMain->IsLocked(true)) {
             SecureString strWalletPass;
             strWalletPass.reserve(100);
 

--- a/src/rpcdarksend.cpp
+++ b/src/rpcdarksend.cpp
@@ -345,7 +345,7 @@ Value masternode(const Array& params, bool fHelp)
         if(activeMasternode.status == MASTERNODE_INPUT_TOO_NEW) return "masternode input must have at least 15 confirmations";
         if(activeMasternode.status == MASTERNODE_STOPPED) return "masternode is stopped";
         if(activeMasternode.status == MASTERNODE_IS_CAPABLE) return "successfully started masternode";
-        if(activeMasternode.status == MASTERNODE_NOT_CAPABLE) return "not capable masternode: " + activeMasternode.notCapableReason;
+        if(activeMasternode.status == MASTERNODE_NOT_CAPABLE) return "not capable masternode(cmd=start): " + activeMasternode.notCapableReason;
         if(activeMasternode.status == MASTERNODE_SYNC_IN_PROCESS) return "sync in process. Must wait until client is synced to start.";
 
         return "unknown";
@@ -467,7 +467,7 @@ Value masternode(const Array& params, bool fHelp)
         if(activeMasternode.status == MASTERNODE_INPUT_TOO_NEW) return "masternode input must have at least 15 confirmations";
         if(activeMasternode.status == MASTERNODE_IS_CAPABLE) return "successfully started masternode";
         if(activeMasternode.status == MASTERNODE_STOPPED) return "masternode is stopped";
-        if(activeMasternode.status == MASTERNODE_NOT_CAPABLE) return "not capable masternode: " + activeMasternode.notCapableReason;
+        if(activeMasternode.status == MASTERNODE_NOT_CAPABLE) return "not capable masternode(cmd=debug): " + activeMasternode.notCapableReason;
         if(activeMasternode.status == MASTERNODE_SYNC_IN_PROCESS) return "sync in process. Must wait until client is synced to start.";
 
         CTxIn vin = CTxIn();

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -588,9 +588,10 @@ Value sendrawtransaction(const Array& params, bool fHelp)
     }
     else
     {
+        std::string errorMessage;
         // push to local node
-        if (!AcceptToMemoryPool(mempool, tx, true, NULL))
-            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX rejected");
+        if (!AcceptToMemoryPool(mempool, tx, true, NULL, errorMessage))
+            throw JSONRPCError(RPC_MISC_ERROR, errorMessage);
     }
     RelayTransaction(tx);
 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -592,7 +592,7 @@ Value sendrawtransaction(const Array& params, bool fHelp)
         if (!AcceptToMemoryPool(mempool, tx, true, NULL))
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX rejected");
     }
-    RelayTransaction(tx, hashTx);
+    RelayTransaction(tx);
 
     return hashTx.GetHex();
 }

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -904,6 +904,9 @@ Value ListReceived(const Array& params, bool fByAccounts)
             nAmount = item.second.nAmount;
             nConf = item.second.nConf;
 
+            if (!fIncludeEmpty && nAmount == 0)
+                 continue;
+
             if (fByAccounts)
             {
                 tallyitem& item = mapAccountTally[strAccount];

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -861,7 +861,7 @@ Value ListReceived(const Array& params, bool fByAccounts)
         const CBitcoinAddress& address = item.first;
         const string& strAccount = item.second;
         map<CBitcoinAddress, tallyitem>::iterator it = mapTally.find(address);
-        if (it == mapTally.end() && !fIncludeEmpty)
+        if ((it == mapTally.end() && !fIncludeEmpty) || !IsMine(*pwalletMain, address.Get()))
             continue;
 
         int64_t nAmount = 0;

--- a/src/version.h
+++ b/src/version.h
@@ -36,9 +36,9 @@ static const int PROTOCOL_VERSION = 60032;
 static const int INIT_PROTO_VERSION = 209;
 
 // disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 60020;
+static const int MIN_PEER_PROTO_VERSION = 60032;
 
-static const int MIN_INSTANTX_PROTO_VERSION = 60020;
+static const int MIN_INSTANTX_PROTO_VERSION = 60032;
 
 static const int MIN_MN_PROTO_VERSION = 60030;
 
@@ -48,7 +48,7 @@ static const int CADDR_TIME_VERSION = 60030;
 
 // only request blocks from nodes outside this range of versions
 static const int NOBLKS_VERSION_START = 0;
-static const int NOBLKS_VERSION_END = 60020;
+static const int NOBLKS_VERSION_END = 60032;
 
 // BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 60000;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3464,7 +3464,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         return false;
     
     // MBK: Added some additional debug information
-    if (MBK_EXTRA_DEBUG) LogPrintf("CWallet::CreateCoinStake() -> [PreInputCollection] nCredit=%d", nCredit);
+    if (MBK_EXTRA_DEBUG) LogPrintf("CWallet::CreateCoinStake() -> [PreInputCollection] nCredit=%d\n", nCredit);
 
     BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
     {
@@ -3498,7 +3498,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
     }
 
     // MBK: Added some additional debugging information
-    if (MBK_EXTRA_DEBUG) LogPrintf("CWallet::CreateCoinStake() -> [AfterInputCollection] nCredit=%d", nCredit);
+    if (MBK_EXTRA_DEBUG) LogPrintf("CWallet::CreateCoinStake() -> [AfterInputCollection] nCredit=%d\n", nCredit);
 
     // Calculate coin age reward
     int64_t nReward;
@@ -3526,7 +3526,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
     }
 
     // MBK: Added some additional debugging information
-    if (MBK_EXTRA_DEBUG) LogPrintf("CWallet::CreateCoinStake() -> nReward=%d, nCredit=%d", nReward, nCredit);
+    if (MBK_EXTRA_DEBUG) LogPrintf("CWallet::CreateCoinStake() -> nReward=%d, nCredit=%d\n", nReward, nCredit);
 
     // Masternode Payments
     int payments = 1;
@@ -3576,7 +3576,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
     int64_t masternodePayment = GetMasternodePayment(pindexPrev->nHeight+1, nReward);
 
     // MBK: Added some additional debugging information
-    if (MBK_EXTRA_DEBUG) LogPrintf("CWallet::CreateCoinStake() -> blockValue=%d, masternodePayment=%d", blockValue, masternodePayment);
+    if (MBK_EXTRA_DEBUG) LogPrintf("CWallet::CreateCoinStake() -> blockValue=%d(%s), masternodePayment=%d(%s)\n", blockValue, FormatMoney(blockValue), masternodePayment, FormatMoney(masternodePayment));
 
     // Set output amount
     if (!hasPayment && txNew.vout.size() == 3) // 2 stake outputs, stake was split, no masternode payment

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1537,7 +1537,7 @@ void CWallet::AvailableCoinsForStaking(vector<COutput>& vCoins, unsigned int nSp
                 continue;
 
             for (unsigned int i = 0; i < pcoin->vout.size(); i++)
-                if (!(pcoin->IsSpent(i)) && IsMine(pcoin->vout[i]) && pcoin->vout[i].nValue >= nMinimumInputValue)
+                if (!IsLockedCoin((*it).first,i) && !(pcoin->IsSpent(i)) && IsMine(pcoin->vout[i]) && pcoin->vout[i].nValue >= nMinimumInputValue)
                     vCoins.push_back(COutput(pcoin, i, nDepth, true));
         }
     }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3576,7 +3576,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
     int64_t masternodePayment = GetMasternodePayment(pindexPrev->nHeight+1, nReward);
 
     // MBK: Added some additional debugging information
-    if (MBK_EXTRA_DEBUG) LogPrintf("CWallet::CreateCoinStake() -> blockValue=%d(%s), masternodePayment=%d(%s)\n", blockValue, FormateMoney(blockValue), masternodePayment, FormatMoney(masternodePayment));
+    if (MBK_EXTRA_DEBUG) LogPrintf("CWallet::CreateCoinStake() -> blockValue=%d(%s), masternodePayment=%d(%s)\n", blockValue, FormatMoney(blockValue), masternodePayment, FormatMoney(masternodePayment));
 
     // Set output amount
     if (!hasPayment && txNew.vout.size() == 3) // 2 stake outputs, stake was split, no masternode payment

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3576,7 +3576,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
     int64_t masternodePayment = GetMasternodePayment(pindexPrev->nHeight+1, nReward);
 
     // MBK: Added some additional debugging information
-    if (MBK_EXTRA_DEBUG) LogPrintf("CWallet::CreateCoinStake() -> blockValue=%d(%s), masternodePayment=%d(%s)\n", blockValue, FormatMoney(blockValue), masternodePayment, FormatMoney(masternodePayment));
+    if (MBK_EXTRA_DEBUG) LogPrintf("CWallet::CreateCoinStake() -> blockValue=%d(%s), masternodePayment=%d(%s)\n", blockValue, FormateMoney(blockValue), masternodePayment, FormatMoney(masternodePayment));
 
     // Set output amount
     if (!hasPayment && txNew.vout.size() == 3) // 2 stake outputs, stake was split, no masternode payment

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1151,7 +1151,7 @@ void CWalletTx::RelayWalletTransaction(CTxDB& txdb)
         {
             uint256 hash = tx.GetHash();
             if (!txdb.ContainsTx(hash))
-                RelayTransaction((CTransaction)tx, hash);
+                RelayTransaction((CTransaction)tx);
         }
     }
     if (!(IsCoinBase() || IsCoinStake()))
@@ -1160,7 +1160,7 @@ void CWalletTx::RelayWalletTransaction(CTxDB& txdb)
         if (!txdb.ContainsTx(hash))
         {
             LogPrintf("Relaying wtx %s\n", hash.ToString());
-            RelayTransaction((CTransaction)*this, hash);
+            RelayTransaction((CTransaction)*this);
         }
     }
 }


### PR DESCRIPTION
### Critical Fix
Fixed issue where wallet was stuck on syncing block 0 when syncing a new blockchain

### Sync Improvements
- track peer block downloads to auto remove stalled peers
- disconnect peer when reached ban threshold (needs proper ban logic implemented)
- disallows access to nodes running wallets less than 2.0.0.0
- dump orphan blocks from peer when they are disconnected (prevents filling orphan block list with unusable blocks)
- add maxorphantx startup flag to cap max orhpan transactions held in memory for running on lightweight machines

### General Improvements
- masternode should ignore if wallet is unlocked for staking only
- locked masternode coins will be ignored when staking
- masternode start will check all possible coin inputs instead of just the first

### General RPC improvements
- Updates listreceivedbyaddress RPC command to return only your addresses when running with minconf=0 and includeempty=true instead of returning all addresses including send addresses from your address book.

- fix GetAccountAddress not committing the new account to the walletdb causing duplicates to be made when running the command again

- setaccount no longer can create new addresses. This was a confusing feature and gave no way to change account names without creating new addresses

- setaccount returns error if trying to change the account of an address that doesn't exist in your wallet

- listreceived now returns (change) addresses

### Added RPC commands for masternodes
- masternode status - dumps your masternode status. includes your active time and status to determine if your masternode is running correctly
-masternode status-all - dumps the above info for all masternodes on the network (only your masternode will include status field)
- masternode init <wallet addr> <ip:port> - allows you to initialise your masternode without editing the linda.conf or masternode.conf files and or restarting the program. Running masternode start will then start your masternode
- masternode addremote <account> <ip:port> <key> <hash> <index> - adds the info to your masternode.conf file (no need to restart Linda-qt or Lindad) running start-many or start-alias will start the appropriate remote masternodes
- masternode removeremote <account> - removes the related account from your masternode.conf file (no need to restart Linda-qt or Lindad) you will need to run the masternode stop to stop these masternodes
- masternode isInit - returns boolean if masternode is enabled and capable of running
- masternode kill - disables masternode. can be re-enable by running init command