### PR TITLE
Masternode UI tab updates and a performance improvement.

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -492,13 +492,39 @@ int GetMasternodeByRank(int findRank, int64_t nBlockHeight, int minProtocol)
 
 int GetMasternodeRank(CTxIn& vin, int64_t nBlockHeight, int minProtocol)
 {
-    std::vector<pair<unsigned int, CTxIn> > vecMasternodeScores;
+    std::vector<pair<unsigned int, CTxIn>> vecMasternodeScores = GetMasternodeScores(nBlockHeight, minProtocol);
+    return GetMasternodeRank(vin, vecMasternodeScores);
+}
 
-    BOOST_FOREACH(CMasterNode& mn, vecMasternodes) {
+int GetMasternodeRank(CTxIn& vin, std::vector<pair<unsigned int, CTxIn>>& vecMasternodeScores)
+{
+    unsigned int rank = 0;
+    BOOST_FOREACH (PAIRTYPE(unsigned int, CTxIn)& s, vecMasternodeScores)
+    {
+        rank++;
+        if(s.second == vin) 
+        {
+            return rank;
+        }
+    }
+
+    return -1;
+}
+
+std::vector<pair<unsigned int, CTxIn>> GetMasternodeScores(int64_t nBlockHeight, int minProtocol)
+{
+    std::vector<pair<unsigned int, CTxIn>> vecMasternodeScores;
+
+    BOOST_FOREACH(CMasterNode& mn, vecMasternodes) 
+    {
         mn.Check();
+        if(mn.protocolVersion < minProtocol)
+        {
+            continue;
+        }
 
-        if(mn.protocolVersion < minProtocol) continue;
-        if(!mn.IsEnabled()) {
+        if(!mn.IsEnabled()) 
+        {
             continue;
         }
 
@@ -511,15 +537,7 @@ int GetMasternodeRank(CTxIn& vin, int64_t nBlockHeight, int minProtocol)
 
     sort(vecMasternodeScores.rbegin(), vecMasternodeScores.rend(), CompareValueOnly());
 
-    unsigned int rank = 0;
-    BOOST_FOREACH (PAIRTYPE(unsigned int, CTxIn)& s, vecMasternodeScores){
-        rank++;
-        if(s.second == vin) {
-            return rank;
-        }
-    }
-
-    return -1;
+    return vecMasternodeScores;
 }
 
 //Get the last hash that matches the modulus given. Processed in reverse order

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -160,7 +160,9 @@ int GetCurrentMasterNode(int mod=1, int64_t nBlockHeight=0, int minProtocol=CMas
 
 int GetMasternodeByVin(CTxIn& vin);
 int GetMasternodeRank(CTxIn& vin, int64_t nBlockHeight=0, int minProtocol=CMasterNode::minProtoVersion);
+int GetMasternodeRank(CTxIn& vin, std::vector<pair<unsigned int, CTxIn>>& vecMasternodeScores);
 int GetMasternodeByRank(int findRank, int64_t nBlockHeight=0, int minProtocol=CMasterNode::minProtoVersion);
+std::vector<pair<unsigned int, CTxIn>> GetMasternodeScores(int64_t nBlockHeight, int minProtocol=CMasterNode::minProtoVersion);
 
 
 // for storing the winning payments

--- a/src/qt/masternodemanager.cpp
+++ b/src/qt/masternodemanager.cpp
@@ -48,6 +48,8 @@ void MasternodeManager::updateNodeList()
         std::string addr = mn.addr.ToString();
         mapMasternodes[QString::fromStdString(addr).normalized(QString::NormalizationForm_D)] = &mn;
     }
+    
+    std::vector<pair<unsigned int, CTxIn>> vecMasternodeScores = GetMasternodeScores(pindexBest->nHeight);
 
     // Update existing masternode rows.
     for(int i=0; i < ui->tableWidget->rowCount(); i++)
@@ -59,7 +61,7 @@ void MasternodeManager::updateNodeList()
             CMasterNode *mn = mapMasternodes.value(addr);
 
             // populate list
-            updateNodeListRow(mn, i);
+            updateNodeListRow(mn, vecMasternodeScores, i);
 
             mapMasternodes.remove(addr);
         }
@@ -74,16 +76,16 @@ void MasternodeManager::updateNodeList()
 
         // populate list
         ui->tableWidget->insertRow(0);
-        updateNodeListRow(mn, 0);
+        updateNodeListRow(mn, vecMasternodeScores, 0);
     }
 }
 
-void MasternodeManager::updateNodeListRow(CMasterNode *mn, int mnRow)
+void MasternodeManager::updateNodeListRow(CMasterNode *mn, std::vector<pair<unsigned int, CTxIn>>& vecMasternodeScores, int mnRow)
 {
     // Address, Rank, Active, Active Seconds, Last Seen, Pub Key
     QTableWidgetItem *activeItem = new QTableWidgetItem(QString::number(mn->IsEnabled()));
     QTableWidgetItem *addressItem = new QTableWidgetItem(QString::fromStdString(mn->addr.ToString()).normalized(QString::NormalizationForm_D));
-    QTableWidgetItem *rankItem = new QTableWidgetItem(QString::number(GetMasternodeRank(mn->vin, pindexBest->nHeight)));
+    QTableWidgetItem *rankItem = new QTableWidgetItem(QString::number(GetMasternodeRank(mn->vin, vecMasternodeScores)));
     QTableWidgetItem *activeSecondsItem = new QTableWidgetItem(QString::number((qint64)(mn->lastTimeSeen - mn->now)));
     int64_t unixTime = mn->lastTimeSeen;
     QDateTime timestamp;

--- a/src/qt/masternodemanager.cpp
+++ b/src/qt/masternodemanager.cpp
@@ -48,7 +48,7 @@ void MasternodeManager::updateNodeList()
         std::string addr = mn.addr.ToString();
         mapMasternodes[QString::fromStdString(addr).normalized(QString::NormalizationForm_D)] = &mn;
     }
-    
+
     std::vector<pair<unsigned int, CTxIn>> vecMasternodeScores = GetMasternodeScores(pindexBest->nHeight);
 
     // Update existing masternode rows.
@@ -74,9 +74,11 @@ void MasternodeManager::updateNodeList()
         mnIterator.next();
         CMasterNode *mn = mnIterator.value();
 
+        int lastRow = ui->tableWidget->rowCount();
+
         // populate list
-        ui->tableWidget->insertRow(0);
-        updateNodeListRow(mn, vecMasternodeScores, 0);
+        ui->tableWidget->insertRow(lastRow);
+        updateNodeListRow(mn, vecMasternodeScores, lastRow);
     }
 }
 

--- a/src/qt/masternodemanager.cpp
+++ b/src/qt/masternodemanager.cpp
@@ -43,7 +43,7 @@ void MasternodeManager::updateNodeList()
 {
     BOOST_FOREACH(CMasterNode mn, vecMasternodes) 
     {
-	bool bFound = false;
+	    bool bFound = false;
         int mnRow = 0;
         for(int i=0; i < ui->tableWidget->rowCount(); i++)
         {
@@ -56,33 +56,35 @@ void MasternodeManager::updateNodeList()
         }
 
         if(mnRow == 0 && !bFound)
+        {
             ui->tableWidget->insertRow(0);
+        }
 
- 	// populate list
-	// Address, Rank, Active, Active Seconds, Last Seen, Pub Key
-	QTableWidgetItem *activeItem = new QTableWidgetItem(QString::number(mn.IsEnabled()));
-	QTableWidgetItem *addressItem = new QTableWidgetItem(QString::fromStdString(mn.addr.ToString()));
-	QTableWidgetItem *rankItem = new QTableWidgetItem(QString::number(GetMasternodeRank(mn.vin, pindexBest->nHeight)));
-	QTableWidgetItem *activeSecondsItem = new QTableWidgetItem(QString::number((qint64)(mn.lastTimeSeen - mn.now)));
-	int64_t unixTime = mn.lastTimeSeen;
-	QDateTime timestamp;
-	timestamp.setTime_t(unixTime);
+        // populate list
+        // Address, Rank, Active, Active Seconds, Last Seen, Pub Key
+        QTableWidgetItem *activeItem = new QTableWidgetItem(QString::number(mn.IsEnabled()));
+        QTableWidgetItem *addressItem = new QTableWidgetItem(QString::fromStdString(mn.addr.ToString()));
+        QTableWidgetItem *rankItem = new QTableWidgetItem(QString::number(GetMasternodeRank(mn.vin, pindexBest->nHeight)));
+        QTableWidgetItem *activeSecondsItem = new QTableWidgetItem(QString::number((qint64)(mn.lastTimeSeen - mn.now)));
+        int64_t unixTime = mn.lastTimeSeen;
+        QDateTime timestamp;
+        timestamp.setTime_t(unixTime);
 	
-	QTableWidgetItem *lastSeenItem = new QTableWidgetItem(timestamp.toString(Qt::SystemLocaleShortDate));
+	    QTableWidgetItem *lastSeenItem = new QTableWidgetItem(timestamp.toString(Qt::SystemLocaleShortDate));
 
-	CScript pubkey;
+	    CScript pubkey;
         pubkey =GetScriptForDestination(mn.pubkey.GetID());
         CTxDestination address1;
         ExtractDestination(pubkey, address1);
         CBitcoinAddress address2(address1);
-	QTableWidgetItem *pubkeyItem = new QTableWidgetItem(QString::fromStdString(address2.ToString()));
+	    QTableWidgetItem *pubkeyItem = new QTableWidgetItem(QString::fromStdString(address2.ToString()));
 	
-	ui->tableWidget->setItem(mnRow, 0, addressItem);
-	ui->tableWidget->setItem(mnRow, 1, rankItem);
-	ui->tableWidget->setItem(mnRow, 2, activeItem);
-	ui->tableWidget->setItem(mnRow, 3, activeSecondsItem);
-	ui->tableWidget->setItem(mnRow, 4, lastSeenItem);
-	ui->tableWidget->setItem(mnRow, 5, pubkeyItem);
+        ui->tableWidget->setItem(mnRow, 0, addressItem);
+        ui->tableWidget->setItem(mnRow, 1, rankItem);
+        ui->tableWidget->setItem(mnRow, 2, activeItem);
+        ui->tableWidget->setItem(mnRow, 3, activeSecondsItem);
+        ui->tableWidget->setItem(mnRow, 4, lastSeenItem);
+        ui->tableWidget->setItem(mnRow, 5, pubkeyItem);
     }
 }
 

--- a/src/qt/masternodemanager.cpp
+++ b/src/qt/masternodemanager.cpp
@@ -65,6 +65,12 @@ void MasternodeManager::updateNodeList()
 
             mapMasternodes.remove(addr);
         }
+        else
+        {
+            // Remove the row if the masternode can't be found.
+            ui->tableWidget->removeRow(i);
+            i--;
+        }
     }
 
     // Add new masternode rows.

--- a/src/qt/masternodemanager.cpp
+++ b/src/qt/masternodemanager.cpp
@@ -46,7 +46,16 @@ void MasternodeManager::updateNodeList()
     BOOST_FOREACH(CMasterNode& mn, vecMasternodes)
     {
         std::string addr = mn.addr.ToString();
-        mapMasternodes[QString::fromStdString(addr).normalized(QString::NormalizationForm_D)] = &mn;
+        QString display = QString::fromStdString(addr).normalized(QString::NormalizationForm_D);
+        int suffixNum = 2;
+
+        while (mapMasternodes.contains(display))
+        {
+            display = QString::fromStdString(addr + " (" + std::to_string(suffixNum) + ")").normalized(QString::NormalizationForm_D);
+            suffixNum++;
+        }
+
+        mapMasternodes[display] = &mn;
     }
 
     std::vector<pair<unsigned int, CTxIn>> vecMasternodeScores = GetMasternodeScores(pindexBest->nHeight);
@@ -63,7 +72,7 @@ void MasternodeManager::updateNodeList()
             CMasterNode *mn = mapMasternodes.value(addr);
 
             // populate list
-            updateNodeListRow(mn, vecMasternodeScores, i);
+            updateNodeListRow(mn, vecMasternodeScores, i, addr);
 
             mapMasternodes.remove(addr);
         }
@@ -81,25 +90,25 @@ void MasternodeManager::updateNodeList()
     {
         mnIterator.next();
         CMasterNode *mn = mnIterator.value();
-
+        
         int lastRow = ui->tableWidget->rowCount();
 
         // populate list
         ui->tableWidget->insertRow(lastRow);
-        updateNodeListRow(mn, vecMasternodeScores, lastRow);
+        updateNodeListRow(mn, vecMasternodeScores, lastRow, mnIterator.key());
     }
 
     ui->tableWidget->setSortingEnabled(true);
 }
 
-void MasternodeManager::updateNodeListRow(CMasterNode *mn, std::vector<pair<unsigned int, CTxIn>>& vecMasternodeScores, int mnRow)
+void MasternodeManager::updateNodeListRow(CMasterNode *mn, std::vector<pair<unsigned int, CTxIn>>& vecMasternodeScores, int mnRow, const QString addr)
 {
     // Address, Rank, Active, Active Seconds, Last Seen, Pub Key
     QTableWidgetItem *activeItem = new QTableWidgetItem();
     int enabled = mn->IsEnabled();
     activeItem->setData(Qt::DisplayRole, enabled);
 
-    QTableWidgetItem *addressItem = new QTableWidgetItem(QString::fromStdString(mn->addr.ToString()).normalized(QString::NormalizationForm_D));
+    QTableWidgetItem *addressItem = new QTableWidgetItem(addr);
     QTableWidgetItem *rankItem = new QTableWidgetItem();
     rankItem->setData(Qt::DisplayRole, GetMasternodeRank(mn->vin, vecMasternodeScores));
 

--- a/src/qt/masternodemanager.cpp
+++ b/src/qt/masternodemanager.cpp
@@ -51,6 +51,8 @@ void MasternodeManager::updateNodeList()
 
     std::vector<pair<unsigned int, CTxIn>> vecMasternodeScores = GetMasternodeScores(pindexBest->nHeight);
 
+    ui->tableWidget->setSortingEnabled(false);
+
     // Update existing masternode rows.
     for(int i=0; i < ui->tableWidget->rowCount(); i++)
     {
@@ -86,15 +88,24 @@ void MasternodeManager::updateNodeList()
         ui->tableWidget->insertRow(lastRow);
         updateNodeListRow(mn, vecMasternodeScores, lastRow);
     }
+
+    ui->tableWidget->setSortingEnabled(true);
 }
 
 void MasternodeManager::updateNodeListRow(CMasterNode *mn, std::vector<pair<unsigned int, CTxIn>>& vecMasternodeScores, int mnRow)
 {
     // Address, Rank, Active, Active Seconds, Last Seen, Pub Key
-    QTableWidgetItem *activeItem = new QTableWidgetItem(QString::number(mn->IsEnabled()));
+    QTableWidgetItem *activeItem = new QTableWidgetItem();
+    int enabled = mn->IsEnabled();
+    activeItem->setData(Qt::DisplayRole, enabled);
+
     QTableWidgetItem *addressItem = new QTableWidgetItem(QString::fromStdString(mn->addr.ToString()).normalized(QString::NormalizationForm_D));
-    QTableWidgetItem *rankItem = new QTableWidgetItem(QString::number(GetMasternodeRank(mn->vin, vecMasternodeScores)));
-    QTableWidgetItem *activeSecondsItem = new QTableWidgetItem(QString::number((qint64)(mn->lastTimeSeen - mn->now)));
+    QTableWidgetItem *rankItem = new QTableWidgetItem();
+    rankItem->setData(Qt::DisplayRole, GetMasternodeRank(mn->vin, vecMasternodeScores));
+
+    QTableWidgetItem *activeSecondsItem = new QTableWidgetItem();
+    activeSecondsItem->setData(Qt::DisplayRole, (qint64)(mn->lastTimeSeen - mn->now));
+
     int64_t unixTime = mn->lastTimeSeen;
     QDateTime timestamp;
     timestamp.setTime_t(unixTime);

--- a/src/qt/masternodemanager.h
+++ b/src/qt/masternodemanager.h
@@ -40,9 +40,9 @@ private:
     ClientModel *clientModel;
     WalletModel *walletModel;
 
-private slots:
     void updateNodeListRow(CMasterNode *mn, std::vector<pair<unsigned int, CTxIn>>& vecMasternodeScores, int mnRow, const QString addr);
 
+private slots:
 };
 
 #endif // MASTERNODEMANAGER_H

--- a/src/qt/masternodemanager.h
+++ b/src/qt/masternodemanager.h
@@ -1,6 +1,8 @@
 #ifndef MASTERNODEMANAGER_H
 #define MASTERNODEMANAGER_H
 
+#include "masternode.h"
+
 #include <QWidget>
 #include <QTimer>
 
@@ -39,6 +41,8 @@ private:
     WalletModel *walletModel;
 
 private slots:
+    void updateNodeListRow(CMasterNode *mn, int mnRow);
+
 };
 
 #endif // MASTERNODEMANAGER_H

--- a/src/qt/masternodemanager.h
+++ b/src/qt/masternodemanager.h
@@ -41,7 +41,7 @@ private:
     WalletModel *walletModel;
 
 private slots:
-    void updateNodeListRow(CMasterNode *mn, int mnRow);
+    void updateNodeListRow(CMasterNode *mn, std::vector<pair<unsigned int, CTxIn>>& vecMasternodeScores, int mnRow);
 
 };
 

--- a/src/qt/masternodemanager.h
+++ b/src/qt/masternodemanager.h
@@ -41,7 +41,7 @@ private:
     WalletModel *walletModel;
 
 private slots:
-    void updateNodeListRow(CMasterNode *mn, std::vector<pair<unsigned int, CTxIn>>& vecMasternodeScores, int mnRow);
+    void updateNodeListRow(CMasterNode *mn, std::vector<pair<unsigned int, CTxIn>>& vecMasternodeScores, int mnRow, const QString addr);
 
 };
 


### PR DESCRIPTION
1. Masternode tab performance improvement.
a. Problem: The masternodes UI tab uses a lot of resources when it refreshes.
b. Solution: Made updates to masternode.cpp that allow for the calculation of masternode scores to be done outside of GetMasternodeRank so that these scores can be passed to GetMasternodeRank for the purpose of making multiple calls to GetMasternodeRank more efficient. Implemented these changes in massternodemanager.cpp.  These changes could also be beneficial to other areas that I haven't updated.
2. Masternode tab sorting.
a. Problem: The masternodes UI tab doesn't allow for any sorting.
b. Solution: Disable sorting at the start of the row update processes and re enable it at the end.  I also updated some of the columns to have numeric values instead of strings so that sorting would work better.
3. Some masternodes not showing up on the masternodes tab.
a. Problem: When multiple masternodes are running under the same ip and port, only one shows up on the masternode tab.
b. Solution: Additional masternodes will now show up with a suffix number appended to the masternode's address in the format: ip:port (number).  An alternative solution would be to show part of the masternode's vin but I thought this approach would be less controversial. 